### PR TITLE
fix: change drex buffer name

### DIFF
--- a/lua/drex.lua
+++ b/lua/drex.lua
@@ -152,7 +152,7 @@ function M.open_directory_buffer(path)
         return
     end
 
-    local buffer_name = 'drex:' .. path
+    local buffer_name = 'drex://' .. path
     local buffer = vim.fn.bufnr('^' .. buffer_name .. '$')
     -- if a corresponding DREX buffer does not exist yet create one
     if buffer == -1 then

--- a/lua/drex/utils.lua
+++ b/lua/drex/utils.lua
@@ -189,7 +189,7 @@ end
 function M.get_root_path(buffer)
     buffer = buffer or api.nvim_get_current_buf()
     local buf_name = api.nvim_buf_get_name(buffer)
-    return buf_name:match("^drex:(.*)$")
+    return buf_name:match("^drex://(.*)$")
 end
 
 ---Set the given `icon` for the specific `row`


### PR DESCRIPTION
Neovim 0.6 introduces a VIM patch that prepends the current working
directory before every file buffer name. This messes with the current
special buffer name used for DREX

In order to fix this issue we change the buffer name structure to a
terminal/special buffer style: "drex://<path>"

see: https://github.com/neovim/neovim/pull/16362

Now `require('drex.utils').get_root_path(<buffer>)` does work again