### PR TITLE
fix(actions): rework copy and move

### DIFF
--- a/lua/drex/actions.lua
+++ b/lua/drex/actions.lua
@@ -125,7 +125,7 @@ local function get_destination_path()
         local same_level_path = utils.get_path(line)
         local inside_path     = utils.get_element(line) .. utils.path_separator
 
-        local target = vim.fn.inputlist({
+        local _, target = pcall(vim.fn.inputlist, {
             'Please choose the specific destination:',
             '1. ' .. same_level_path,
             '2. ' .. inside_path,
@@ -142,271 +142,6 @@ local function get_destination_path()
     else
         return utils.get_path(line)
     end
-end
-
----Recursively delete a directory and all of its content
----If an error occurs during the process return its message, otherwise return `nil`
----@param path string The directory to delete
----@return string? error
-local function delete_directory(path)
-    local data, error = luv.fs_scandir(path)
-    if error then
-        return error
-    end
-
-    while true do
-        local name, type = luv.fs_scandir_next(data)
-
-        if not name then
-            break
-        end
-
-        local new_path = path .. utils.path_separator .. name
-        if type == 'directory' then
-            error = delete_directory(new_path)
-        else
-            _, error = luv.fs_unlink(new_path)
-        end
-
-        if error then
-            return error
-        end
-    end
-
-    _, error = luv.fs_rmdir(path)
-    return error
-end
-
----Copy an element from `source` to `destination`
----For files this simply uses `vim.loop.fs_copyfile`
----For directories this will loop through all contained files (using `vim.loop.fs_scandir`) and recursively call itself
----@param source string The source location of the element that should be copied
----@param destination string The destination location to which the element should be copied
----@return table files All files which were successfully copied
----@return table errors All errors which occurred during the copy process
-local function copy(source, destination)
-    local source_stats = luv.fs_stat(source)
-    if source_stats and source_stats.type == 'file' then
-        local success, error = luv.fs_copyfile(source, destination, {})
-        if not success then
-            return {}, { error }
-        else
-            return { destination }, {}
-        end
-    end
-
-    local data, error, _ = luv.fs_scandir(source)
-    if error ~= nil then
-        return {}, { error }
-    end
-
-    local total_files = {}
-    local total_errors = {}
-
-    local success, mkdir_error = luv.fs_mkdir(destination, source_stats.mode)
-    if not success then
-        return {}, { mkdir_error }
-    end
-
-    while true do
-        local name, _ = luv.fs_scandir_next(data)
-        if not name then
-            break
-        end
-
-        local src_path  = source .. utils.path_separator .. name
-        local dest_path = destination .. utils.path_separator .. name
-
-        local files, errors = copy(src_path, dest_path)
-
-        for i = 1, #files do
-            total_files[#total_files + 1] = files[i]
-        end
-        for i = 1, #total_errors do
-            total_errors[#total_errors + 1] = errors[i]
-        end
-    end
-
-    -- remove the directory if nothing was copied
-    if #total_files == 0 then
-        delete_directory(destination)
-    end
-
-    return total_files, total_errors
-end
-
----Search for buffers named `old_name` and rename them to `new_name`
----@param old_name string
----@param new_name string
-local function rename_loaded_buffers(old_name, new_name)
-    for _, buf in ipairs(api.nvim_list_bufs()) do
-        if api.nvim_buf_is_loaded(buf) then
-            local buf_name = api.nvim_buf_get_name(buf)
-            if utils.starts_with(buf_name, old_name) then
-                local new_buf_name = buf_name:gsub(utils.escape(old_name), new_name)
-                api.nvim_buf_set_name(buf, new_buf_name)
-                api.nvim_buf_call(buf, function()
-                    vim.cmd('silent! w!')  -- avoid 'overwrite existing file' error
-                    vim.cmd('silent edit') -- to re-attach LSP etc.
-                end)
-            end
-        end
-    end
-end
-
----Paste all DREX clipboard entries at the current location
----This will show a warning if there are no elements in the clipboard
----
----If you "copy" entries (`move` == false) the DREX clipboard entries will be untouched
----So you can continue copying the contained elements to other locations
----
----If you "move" entries (`move` == true) the DREX clipboard entries will be updated to match the new location
----
----@param move boolean Indicator if the entries should be moved (removed from their current location) or copied
-local function paste(move)
-    local elements = get_clipboard_entries('desc')
-
-    -- check for an empty clipboard
-    if vim.tbl_count(elements) == 0 then
-        local action_string = move and 'move' or 'paste'
-        vim.notify('The clipboard is empty! There is nothing to ' .. action_string .. '...', vim.log.levels.INFO, { title = 'DREX' })
-        return
-    end
-
-    local dest_path = get_destination_path()
-    if not dest_path then
-        return
-    end
-
-    local element_counter = 0 -- number of elements which have been moved/copied
-    local files_counter = 0   -- number of files which have been copied (only for 'copy')
-    local errors_found = {}   -- all errors found during the move/copy process
-
-    for _, element in ipairs(elements) do
-        local name = element:match('.*'..utils.path_separator..'(.*)$')
-        local new_element = dest_path .. name
-
-        ::rename_check::
-        -- check if an element with the same name already exists
-        local new_element_stats = luv.fs_stat(new_element)
-        local action = 1
-        if new_element_stats then
-             action = vim.fn.confirm(new_element .. ' already exists. Overwrite?', '&Yes\n&No\n&Rename', 2)
-        end
-
-        if action ~= 2 then     -- user did NOT choose 'No'
-            if action == 3 then -- user did choose 'Rename'
-                new_element = vim.fn.input('New name: ', new_element)
-                goto rename_check
-            end
-
-            if move then
-                local success, error = luv.fs_rename(element, new_element)
-                if success then
-                    rename_loaded_buffers(element, new_element)
-                    M.clipboard[element] = nil
-                    M.clipboard[new_element] = true
-                    element_counter = element_counter + 1
-                else
-                    table.insert(errors_found, error)
-                end
-            else
-                local files, errors = copy(element, new_element)
-
-                if #files> 0 then
-                    element_counter = element_counter + 1
-                    files_counter = files_counter + #files
-                end
-
-                for i = 1, #errors do
-                    errors_found[#errors_found + 1] = errors[i]
-                end
-
-                -- update buffers in windows which have been overwritten by pasting
-                for _, win in ipairs(api.nvim_list_wins()) do
-                    local buffer = api.nvim_win_get_buf(win)
-                    if vim.tbl_contains(files, api.nvim_buf_get_name(buffer)) then
-                        api.nvim_buf_call(buffer, function() vim.cmd(':silent edit!') end)
-                    end
-                end
-            end
-        end
-    end
-
-    if element_counter > 0 then
-        local msg
-        local suffix = element_counter > 1 and 's' or ''
-
-        if move then
-            msg = 'Moved ' .. element_counter .. ' element' .. suffix
-            reload_drex_syntax()
-        else
-            msg = 'Copied ' .. element_counter .. ' element' .. suffix .. ' (' .. files_counter .. ' file' .. suffix .. ')'
-        end
-
-        vim.notify(msg, vim.log.levels.INFO, { title = 'DREX' })
-    end
-
-    if #errors_found > 0 then
-        local msg = table.concat(errors_found, '\n')
-        vim.notify('Could not ' .. (move and 'move' or 'copy') .. ' several elements:\n' .. msg, vim.log.levels.ERROR, { title = 'DREX' })
-    end
-end
-
----Create all non-existent directories of `path`
----This will not create files but only directories!
----
----For example:
----'/home/user/dir/test.json' will create the directories 'home', 'user' and 'dir' (if they do not exists already) but NOT the file 'test.json'
----
----The return value is a table containing two entries:
----- The part of the path which did already exist
----- The part of the path which was created by this function (or `nil` if nothing was created)
----
----For example:
----<pre>
----{ '/home/user/', '/test' }
----</pre>
----
----@param path string The path to create directories for (absolute path)
----@return table
-local function create_directories(path)
-    local path_segments = vim.split(path, utils.path_separator)
-
-    -- if path does not start with '/' or 'C:\' it is not absolute
-    if not (path_segments[1] == "" or path_segments[1]:find('[a-zA-Z]:')) then
-        -- todo? log into some debug file
-        return
-    end
-
-    local tmp_path = path_segments[1]
-    -- remove first "" or "C:" entry
-    table.remove(path_segments, 1)
-    -- remove "" or the file name from the end of the list
-    table.remove(path_segments, #path_segments)
-
-    local existing_path -- part of `path` which does already exist
-    local created_path  -- part of `path` which was created
-
-    for _, segment in ipairs(path_segments) do
-        local parent_path = tmp_path .. utils.path_separator
-
-        tmp_path = tmp_path .. utils.path_separator .. segment
-        local success = luv.fs_mkdir(tmp_path, 493)
-
-        -- the first nonexistent part of `path` was created
-        if not existing_path and success then
-            existing_path = parent_path
-            created_path = path:gsub(utils.escape(parent_path), '', 1)
-        end
-    end
-
-    -- no directory needed to be created
-    if not existing_path then
-        existing_path = tmp_path .. utils.path_separator
-    end
-
-    return { existing_path, created_path }
 end
 
 -- ####################################
@@ -591,6 +326,430 @@ end
 -- ### file action related functions
 -- ####################################
 
+---Delete an `element`
+---If the element is a directory this also deletes all of its content
+---@param element string The element you want to delete
+---@param element_type? string (Optional) The type of the element, if already known
+---@return boolean success Indicates if the deletion was successful
+---@return string? error The corresponding error message if there was one
+local function delete_element(element, element_type)
+    element_type = element_type or luv.fs_lstat(element).type
+
+    if element_type == 'directory' then
+        local data, scan_error = luv.fs_scandir(element)
+        if scan_error then
+            return false, scan_error
+        end
+
+        while true do
+            local name, type = luv.fs_scandir_next(data)
+            if not name then
+                break
+            end
+
+            local sub_element = element .. utils.path_separator .. name
+            local success, error = delete_element(sub_element, type)
+
+            if not success then
+                return false, error
+            end
+        end
+
+        local success, error = luv.fs_rmdir(element)
+        return success, error
+    end
+
+    -- delete non-directory element
+    local success, error = luv.fs_unlink(element)
+    if success then
+        return true, nil
+    end
+
+    return false, error
+end
+
+---Copy `source_element` to `target_element`
+---@param source_element string
+---@param target_element string
+---@param force? boolean If `true` overwrite existing files and directories without asking for confirmation
+---@return string? copied_element The copied element (can differ from `target_element` due to renaming) or `nil` if the element was not copied
+---@return table copied_files A list of all files which have been copied successfully (might just be the `source_element` for a single file or more if it is a directory)
+---@return table errors A list of errors which might have occurred during the copy process
+local function copy_element(source_element, target_element, force)
+    local source_element_stats = luv.fs_lstat(source_element)
+    if not source_element_stats then
+        return nil, {}, { source_element .. ' does not exist!' }
+    end
+
+    if source_element_stats.type ~= 'file' and source_element_stats.type ~= 'directory' then
+        return nil, {}, { "Can't copy '" .. source_element .. "'. Only files and directories are supported not " .. source_element_stats.type .. '!' }
+    end
+
+    ::check_target::
+    local target_element_stats = luv.fs_lstat(target_element)
+    if target_element_stats then
+        local action = 0
+        local element_name = source_element:match('.*'..utils.path_separator..'(.*)$')
+        local target_path = target_element:sub(1, #target_element - #element_name - 1)
+
+        if force then
+            action = 1
+        elseif source_element_stats.type == 'directory' and target_element_stats.type == 'directory' then
+            local merge_msg = table.concat({
+                '[CONFIRM MERGE]',
+                'A %s named "%s" already exists in "%s"',
+                "Do you want to merge it with the %s you're copying? (All existing elements will be overwritten)"
+            }, '\n')
+            action = vim.fn.confirm(
+                merge_msg:format(target_element_stats.type, element_name, target_path, source_element_stats.type),
+                '&Yes\n&No\n&Rename',
+                2)
+        else
+            local confirm_msg = table.concat({
+                '[CONFIRM OVERWRITE]',
+                'A %s named "%s" already exists in "%s"',
+                "Do you want to overwrite it with the %s you're copying?"
+            }, '\n')
+            action = vim.fn.confirm(
+                confirm_msg:format(target_element_stats.type, element_name, target_path, source_element_stats.type),
+                '&Yes\n&No\n&Rename',
+                2)
+        end
+
+        if action == 0 or action == 2 then
+            return nil, {}, {}
+        end
+
+        if action == 1 then
+            if source_element_stats.type ~= target_element_stats.type then
+                local success, error = delete_element(target_element, target_element_stats.type)
+                if not success then
+                    return nil, {}, { "Could not overwrite the ".. target_element_stats.type .. " '" .. target_element .. "':\n" .. error }
+                end
+            end
+        end
+
+        if action == 3 then
+            local status_ok, new_name = pcall(vim.fn.input, 'New name: ', target_element)
+            if status_ok and new_name ~= '' then
+                target_element = new_name
+            end
+            goto check_target -- check again
+        end
+    end
+
+    if source_element_stats.type == 'file' then
+        local success, error = luv.fs_copyfile(source_element, target_element, {})
+        if success then
+            return target_element, { target_element }, {}
+        else
+            return nil, {}, { error }
+        end
+    end
+
+    local data, error = luv.fs_scandir(source_element)
+    if error then
+        return nil, {}, { error }
+    end
+
+    local success, mkdir_error = luv.fs_mkdir(target_element, source_element_stats.mode)
+    if not success then
+        -- do not abort if the new directory already exists
+        if not utils.starts_with(mkdir_error, 'EEXIST') then
+            return nil, {}, { mkdir_error }
+        end
+    end
+
+    local total_files = {}
+    local total_errors = {}
+
+    while true do
+        local name, _ = luv.fs_scandir_next(data)
+        if not name then
+            break
+        end
+
+        local src_path  = source_element .. utils.path_separator .. name
+        local dest_path = target_element .. utils.path_separator .. name
+
+        local _, files, errors = copy_element(src_path, dest_path, true)
+
+        for i = 1, #files do
+            total_files[#total_files + 1] = files[i]
+        end
+        for i = 1, #errors do
+            total_errors[#total_errors + 1] = errors[i]
+        end
+    end
+
+    return target_element, total_files, total_errors
+end
+
+---Search for buffers named `old_name` and rename them to `new_name`
+---@param old_name string
+---@param new_name string
+local function rename_loaded_buffers(old_name, new_name)
+    for _, buf in ipairs(api.nvim_list_bufs()) do
+        if api.nvim_buf_is_loaded(buf) then
+            local buf_name = api.nvim_buf_get_name(buf)
+            if utils.starts_with(buf_name, old_name) then
+                local new_buf_name = buf_name:gsub(utils.escape(old_name), new_name)
+                api.nvim_buf_set_name(buf, new_buf_name)
+                api.nvim_buf_call(buf, function()
+                    vim.cmd('silent! w!')  -- avoid 'overwrite existing file' error
+                    vim.cmd('silent edit') -- to re-attach LSP etc.
+                end)
+            end
+        end
+    end
+end
+
+---Create all non-existent directories of `path`
+---This will not create files but only directories!
+---
+---For example:
+---'/home/user/dir/test.json' will create the directories 'home', 'user' and 'dir' (if they do not exists already) but NOT the file 'test.json'
+---
+---The return value is a table containing two entries:
+---- The part of the path which did already exist
+---- The part of the path which was created by this function (or `nil` if nothing was created)
+---
+---For example:
+---<pre>
+---{ '/home/user/', '/test' }
+---</pre>
+---
+---@param path string The path to create directories for (absolute path)
+---@return table
+local function create_directories(path)
+    local path_segments = vim.split(path, utils.path_separator)
+
+    -- if path does not start with '/' or 'C:\' it is not absolute
+    if not (path_segments[1] == "" or path_segments[1]:find('[a-zA-Z]:')) then
+        -- todo? log into some debug file
+        return
+    end
+
+    local tmp_path = path_segments[1]
+    -- remove first "" or "C:" entry
+    table.remove(path_segments, 1)
+    -- remove "" or the file name from the end of the list
+    table.remove(path_segments, #path_segments)
+
+    local existing_path -- part of `path` which does already exist
+    local created_path  -- part of `path` which was created
+
+    for _, segment in ipairs(path_segments) do
+        local parent_path = tmp_path .. utils.path_separator
+
+        tmp_path = tmp_path .. utils.path_separator .. segment
+        local success = luv.fs_mkdir(tmp_path, 493)
+
+        -- the first nonexistent part of `path` was created
+        if not existing_path and success then
+            existing_path = parent_path
+            created_path = path:gsub(utils.escape(parent_path), '', 1)
+        end
+    end
+
+    -- no directory needed to be created
+    if not existing_path then
+        existing_path = tmp_path .. utils.path_separator
+    end
+
+    return { existing_path, created_path }
+end
+
+---Rename `old_element` to `new_element`
+---@param old_element string
+---@param new_element string
+---@return string? renamed_element The new renamed element (can differ from `new_element` due to renaming) or `nil` if the element was not renamed
+---@return string? error An error message in case anything did go wrong
+local function rename_element(old_element, new_element)
+    local old_element_stats = luv.fs_lstat(old_element)
+    if not old_element_stats then
+        return nil, old_element .. ' does not exist!'
+    end
+
+    if old_element == new_element then
+        return nil, nil
+    end
+
+    local confirm_msg = table.concat({
+        '[CONFIRM OVERWRITE]',
+        'A %s named "%s" already exists in "%s"',
+        "Do you want to overwrite it with the %s you're moving?"
+    }, '\n')
+
+    local second_try = false
+    ::rename::
+    local new_element_stats = luv.fs_lstat(new_element)
+    local element_name = new_element:match('.*'..utils.path_separator..'(.*)$')
+    local parent_path = new_element:sub(1, #new_element - #element_name - 1)
+
+    -- `fs_rename` does not fail on existing files and would just overwrite them, so we have to check manually
+    if new_element_stats and new_element_stats.type ~= 'directory' and old_element_stats.type ~= 'directory' then
+        local action = vim.fn.confirm(
+            confirm_msg:format(new_element_stats.type, element_name, parent_path, old_element_stats.type),
+            '&Yes\n&No\n&Rename',
+            2
+        )
+        vim.cmd('redraw') -- clear input area
+
+        if action == 0 or action == 2 then
+            return nil, nil
+        end
+
+        if action == 3 then
+            new_element = vim.fn.input('New name: ', new_element)
+            goto rename
+        end
+    end
+
+    create_directories(new_element)
+
+    local success, error = luv.fs_rename(old_element, new_element)
+    if success then
+        rename_loaded_buffers(old_element, new_element)
+        return new_element, nil
+    elseif not second_try then
+        local action = 0
+        if utils.starts_with(error, 'ENOTDIR') or utils.starts_with(error, 'EISDIR') then
+            action = vim.fn.confirm(
+                confirm_msg:format(new_element_stats.type, element_name, parent_path, old_element_stats.type),
+                '&Yes\n&No\n&Rename',
+                2
+            )
+        elseif utils.starts_with(error, 'ENOTEMPTY') then
+            action = vim.fn.confirm(
+                -- clarify that it's NOT a merge but an overwrite (old data will be lost)
+                confirm_msg:format(new_element_stats.type, element_name, parent_path, old_element_stats.type) .. ' (This is NOT a merge!)',
+                '&Yes\n&No\n&Rename',
+                2
+            )
+        else
+            return nil, error
+        end
+        vim.cmd('redraw') -- clear input area
+
+        if action == 0 or action == 2 then
+            return nil, nil
+        end
+
+        if action == 1 then
+            success, error = delete_element(new_element)
+            if success then
+                second_try = true -- prevent infinite loops
+                goto rename
+            end
+        end
+
+        if action == 3 then
+            new_element = vim.fn.input('New name: ', new_element)
+            goto rename
+        end
+    end
+
+    return nil, error
+end
+
+---Paste all elements from the DREX clipboard at the current location
+---
+---If you copy the elements (`move` == false) the DREX clipboard entries will be untouched
+---So you can continue copying the original elements to other locations
+---
+---If you move the elements (`move` == true) the DREX clipboard entries will be updated to match the new location
+---@param move boolean Should the entries be moved (removed from their current location) or copied
+local function paste(move)
+    local elements = get_clipboard_entries('desc')
+
+    -- check for an empty clipboard
+    if vim.tbl_count(elements) == 0 then
+        local action_string = move and 'move' or 'paste'
+        vim.notify('The clipboard is empty! There is nothing to ' .. action_string .. '...', vim.log.levels.INFO, { title = 'DREX' })
+        return
+    end
+
+    local dest_path = get_destination_path()
+    if not dest_path then
+        return
+    end
+
+    local pasted_elements = {} -- the elements which have been pasted
+    local files_counter = 0    -- number of files which have been copied (only for 'copy')
+    local errors_found = {}    -- all errors found during the move/copy process
+
+    for _, element in ipairs(elements) do
+        vim.cmd('redraw') -- clear command input area
+        local name = element:match('.*'..utils.path_separator..'(.*)$')
+        local new_element = dest_path .. name
+
+        if move then
+            local renamed_element, error = rename_element(element, new_element)
+            if renamed_element then
+                M.clipboard[element] = nil
+                M.clipboard[renamed_element] = true
+                table.insert(pasted_elements, renamed_element)
+            else
+                table.insert(errors_found, error)
+            end
+        else
+            local copied_element, files, errors = copy_element(element, new_element)
+
+            if copied_element then
+                table.insert(pasted_elements, copied_element)
+            end
+            files_counter = files_counter + #files
+            for i = 1, #errors do
+                errors_found[#errors_found + 1] = errors[i]
+            end
+
+            -- update buffers in windows which have been overwritten by pasting
+            for _, win in ipairs(api.nvim_list_wins()) do
+                local buffer = api.nvim_win_get_buf(win)
+                if vim.tbl_contains(files, api.nvim_buf_get_name(buffer)) then
+                    api.nvim_buf_call(buffer, function() vim.cmd(':silent edit!') end)
+                end
+            end
+        end
+    end
+
+    local element_counter = #pasted_elements
+    if element_counter > 0 then
+        local msg
+        local suffix = element_counter > 1 and 's' or ''
+
+        if move then
+            msg = 'Moved ' .. element_counter .. ' element' .. suffix
+            reload_drex_syntax()
+        else
+            msg = 'Copied ' .. element_counter .. ' element' .. suffix .. ' (' .. files_counter .. ' file' .. suffix .. ')'
+        end
+
+        -- if only a single element should and successfully was copied focus it afterwards
+        if #elements == 1 and element_counter == 1 then
+            local new_element = pasted_elements[1]
+            local window = api.nvim_get_current_win()
+            local focus_fn = function()
+                require('drex').focus_element(window, new_element)
+            end
+
+            if not fs.post_next_reload(vim.fn.fnamemodify(new_element, ':h') .. utils.path_separator,
+                api.nvim_get_current_buf(),
+                focus_fn) then
+                focus_fn()
+            end
+        end
+
+        vim.notify(msg, vim.log.levels.INFO, { title = 'DREX' })
+    end
+
+    if #errors_found > 0 then
+        local msg = table.concat(errors_found, '\n')
+        vim.notify('Could not ' .. (move and 'move' or 'copy') .. ' several elements:\n' .. msg, vim.log.levels.ERROR, { title = 'DREX' })
+    end
+end
+
 ---Copy and paste all DREX clipboard entries to the current location
 function M.copy_and_paste()
     paste(false)
@@ -599,46 +758,6 @@ end
 ---Cut and move all DREX clipboard entries to the current location
 function M.cut_and_move()
     paste(true)
-end
-
----Rename `old_element` to `new_element`
----@param old_element string
----@param new_element string
----@return boolean success
----@return string error
-local function rename_element(old_element, new_element)
-    if old_element == new_element then
-        return false
-    end
-
-    local stats = luv.fs_stat(new_element)
-    if stats then
-        if stats.type == 'directory' then
-            local data, error = luv.fs_scandir(new_element)
-            if error then
-                return false, error
-            end
-
-            local item = luv.fs_scandir_next(data)
-            if item then
-                return false, new_element .. ' is a non-empty directory. You have to manually check this!'
-            end
-        end
-
-        if vim.fn.confirm(new_element .. ' already exists. Overwrite?', '&Yes\n&No', 2) == 1 then
-            return false
-        end
-    end
-
-    create_directories(new_element)
-    local _, error = luv.fs_rename(old_element, new_element)
-
-    if error then
-        return false, error
-    end
-
-    rename_loaded_buffers(old_element, new_element)
-    return true
 end
 
 ---Rename multiple elements in a separate buffer
@@ -764,12 +883,13 @@ function M.multi_rename(mode)
 end
 
 ---Rename the element under the cursor
----The path of the renamed element can be changed and new directories will be created automatically
+---The path of the renamed element can be changed and new non-existing directories will be created automatically
 function M.rename()
     local old_element = utils.get_element(api.nvim_get_current_line())
-    local new_element = vim.fn.input('New name: ', old_element)
+    local old_element_stats = luv.fs_lstat(old_element)
+    local status_ok, new_element = pcall(vim.fn.input, 'Rename '..old_element_stats.type..': ', old_element)
 
-    if new_element == '' then
+    if not status_ok or new_element == '' then
         return
     end
     vim.cmd('redraw') -- clear input area
@@ -809,35 +929,50 @@ function M.create()
         return
     end
 
-    local new_element = vim.fn.input('New file/directory: ', dest_path, 'dir')
-
+    local status_ok, user_input = pcall(vim.fn.input, 'New file/directory: ', dest_path, 'dir')
     -- if users cancels input (e.g. via 'esc') the return value is also empty
-    if new_element == '' then
+    if not status_ok or user_input == '' then
         return
     end
 
-    local existing_base_path = create_directories(new_element)[1]
+    ::check_existance::
+    local new_element = user_input:gsub(utils.path_separator..'$', '')
+    local new_element_stats = luv.fs_lstat(new_element)
 
-    -- check if only directories should be created
-    if not utils.ends_with(new_element, utils.path_separator) then
-        -- check if a file with this name already exists
-        if luv.fs_stat(new_element) then
-            local action = vim.fn.confirm(new_element .. ' already exists. Overwrite?', '&Yes\n&No', 2)
-            if action ~= 1 then
-                return
-            end
+    if new_element_stats then
+        local confirm_msg = table.concat({
+            'A %s named "%s" already exists',
+            'Do you want to overwrite it?'
+        }, '\n')
+        local action = vim.fn.confirm(confirm_msg:format(new_element_stats.type, new_element), '&Yes\n&No\n&Rename', 2)
+        if action == 0 or action == 2 then
+            return
         end
 
+        if action == 1 then
+            delete_element(new_element, new_element_stats.type)
+        end
+
+        if action == 3 then
+            user_input = vim.fn.input('New name: ', user_input, 'dir')
+            goto check_existance
+        end
+    end
+
+    local existing_base_path = create_directories(user_input)[1]
+
+    -- check if only directories should be created
+    if not utils.ends_with(user_input, utils.path_separator) then
         local mode = luv.constants.O_CREAT + luv.constants.O_WRONLY + luv.constants.O_TRUNC
-        local fd, error = luv.fs_open(new_element, 'w', mode)
+        local fd, error = luv.fs_open(user_input, 'w', mode)
         if error then
-            vim.notify("Could not create file '" .. new_element .. "':\n" .. error, vim.log.levels.ERROR, { title = 'DREX' })
+            vim.notify("Could not create file '" .. user_input .. "':\n" .. error, vim.log.levels.ERROR, { title = 'DREX' })
             return
         end
 
         -- libuv creates files with executable permissions (1101)
         -- therefore chmod the result to default permissions ('rw-r--r--')
-        luv.fs_chmod(new_element, 420)
+        luv.fs_chmod(user_input, 420)
         luv.fs_close(fd)
     end
 
@@ -913,14 +1048,9 @@ function M.delete(mode)
     local delete_counter = 0
 
     for index, element in ipairs(elements) do
-        local error
-        if luv.fs_stat(element).type == 'directory' then
-            error = delete_directory(element)
-        else
-            _, error = luv.fs_unlink(element)
-        end
+        local success, error = delete_element(element)
 
-        if error then
+        if not success then
             utils.echo("Could not delete '" .. element .. "':\n" .. error, false, 'ErrorMsg')
             if index < #elements then
                 if vim.fn.confirm('Continue?', '&Yes\n&No', 1) == 1 then
@@ -962,7 +1092,7 @@ function M.stats()
     utils.check_if_drex_buffer(0)
 
     local element = utils.get_element(api.nvim_get_current_line())
-    local details = luv.fs_stat(element)
+    local details = luv.fs_lstat(element)
 
     if not details then
         vim.notify("Could not read details for '" .. element .. "'!", vim.log.levels.ERROR, { title = 'DREX' })


### PR DESCRIPTION
- streamline copy, move, delete and rename
- group together them inside the 'actions.lua' file
- catch edge cases for overwriting
- use `lstat` to better handle links
- catch <C-c> for `vim.fn.inputlist`

This is a rather big restructure, but I am testing this now for quite some time. It should fix several issues and catch certain edge cases (e.g. copy a directory to a folder where a file with the same name already exists). In a future step it probably makes sense to extract those "file actions" into its own file, but that is the task for another refactor