### PR TITLE
feat: add ability to choose path for creating files/folders

### DIFF
--- a/lua/drex/actions.lua
+++ b/lua/drex/actions.lua
@@ -937,8 +937,9 @@ end
 
 ---Create a new element (file or directory)
 ---Nonexistent directories of the new path will be created as well
-function M.create()
-    local dest_path = get_destination_path()
+---@param dest_path string? (Optional) Path of the newly created element, if not provided use the element under the cursor
+function M.create(dest_path)
+    local dest_path = dest_path or get_destination_path()
     if not dest_path then
         return
     end


### PR DESCRIPTION
Add actions to enable creation of files and folders to a specific path (inside path or current path)


```lua
require('drex.config').configure({
  keybindings = {
    ['n'] = {
      ['a'] = '<cmd>lua require("drex.actions").create_same_level_path()<CR>',
      ['A'] = '<cmd>lua require("drex.actions").create_inside_path()<CR>',
    }
  }
})
```