### PR TITLE
Add the lualine extension

### DIFF
--- a/lua/lualine/extensions/drex.lua
+++ b/lua/lualine/extensions/drex.lua
@@ -1,0 +1,21 @@
+local M = {}
+
+local short_path = function()
+    local path = require('drex.utils').get_root_path(0)
+    return vim.fn.fnamemodify(path, ':~')
+end
+
+local clipboard_entries = function()
+    return vim.tbl_count(require('drex.actions').clipboard)
+end
+
+M.sections = {
+  lualine_a = { short_path },
+  lualine_z = { clipboard_entries },
+}
+
+M.filetypes = {
+  'drex',
+}
+
+return M


### PR DESCRIPTION
I had opened an equivalent [pr](https://github.com/nvim-lualine/lualine.nvim/pull/782) at the lualine repo but the maintainer was unsure whether you want to support a lualine extension. Additionally it probably makes sense to put the extension into the drex repo since it uses internal functions which may be subject to breaking changes.  So if you are fine with the maintenance of the extension, here it is.
