### PR TITLE
open drex in a buffer and find element

### DIFF
--- a/lua/drex.lua
+++ b/lua/drex.lua
@@ -253,7 +253,9 @@ function M.find_element(path)
 
     M.open_directory_buffer('.')
 
-    require('drex.elements').focus_element(api.nvim_get_current_win(), path)
+    if not utils.is_directory(path) then
+        require('drex.elements').focus_element(api.nvim_get_current_win(), path)
+    end
 end
 
 return M

--- a/lua/drex.lua
+++ b/lua/drex.lua
@@ -248,4 +248,12 @@ function M.reload_directory(buffer, path)
     end
 end
 
+function M.find_element(path)
+    path = utils.expand_path(path)
+
+    M.open_directory_buffer('.')
+
+    require('drex.elements').focus_element(api.nvim_get_current_win(), path)
+end
+
 return M

--- a/plugin/drex.lua
+++ b/plugin/drex.lua
@@ -19,6 +19,12 @@ end, {
     complete = 'dir',
 })
 
+vim.api.nvim_create_user_command('DrexFindFile', function()
+    require('drex').find_element('%')
+end, {
+    desc = 'Jump to the current file in the DREX buffer and focus it'
+})
+
 vim.api.nvim_create_user_command('DrexDrawerOpen', function()
     require('drex.drawer').open()
 end, {


### PR DESCRIPTION
First of all, thanks for developing Drex. The package is very nice and offers most of the features I'm looking for.

While using it though, I missed a function to open Drex in a buffer and locate the file in the file tree, similar to DrexDrawerFindFileAndFocus. Therefore, I decided to dig into the code and change it myself.

As you can see the changes are quite simple and it works properly on my side... I hope this is enough for now.