### PR TITLE
feat: add drawer side option

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,11 @@ DREX also comes with a simple project drawer functionality
 - `l` expands the current element
   - If it is a directory open its content in a subtree
   - If it is a file open the file in the current window
-  > `<Right>` and `<2-LeftMouse>` are alternative keybindings
+    > `<Right>` and `<2-LeftMouse>` are alternative keybindings
 - `h` collapses the current directories subtree
   - If the element under the cursor is an open directory collapse it
   - Otherwise collapse the parent directory of the element
-  > `<Left>` and `<RightMouse>` are alternative keybindings
+    > `<Left>` and `<RightMouse>` are alternative keybindings
 - `<C-v>` opens a file in a vertical split
 - `<C-x>` opens a file in a horizontal split
 - `<C-t>` opens a file in a new tab
@@ -136,10 +136,10 @@ DREX also comes with a simple project drawer functionality
 
 ## Configuration
 
-There is no initial setup needed to use DREX  
+There is no initial setup needed to use DREX
 However you may configure certain settings to your liking
 
-Check out `:help drex-configuration` for more details about the individual options  
+Check out `:help drex-configuration` for more details about the individual options
 See also the wiki pages about [configuration](https://github.com/TheBlob42/drex.nvim/wiki/Configuration) and [custom actions](https://github.com/TheBlob42/drex.nvim/wiki/Custom-Actions) for more information about further customization
 
 <details>
@@ -171,6 +171,7 @@ require('drex.config').configure {
         return aname < bname
     end,
     drawer = {
+        side = 'left',
         default_width = 30,
         window_picker = {
             enabled = true,
@@ -229,6 +230,7 @@ require('drex.config').configure {
     on_leave = nil,
 }
 ```
+
 </details>
 
 ## Internals
@@ -241,4 +243,4 @@ See also `:help drex-customization` and the [Wiki](https://github.com/TheBlob42/
 
 - [nvim-tree](https://github.com/kyazdani42/nvim-tree.lua)
 - [vim-dirvish](https://github.com/justinmk/vim-dirvish)
-- [fern](https://github.com/lambdalisue/fern.vim) 
+- [fern](https://github.com/lambdalisue/fern.vim)

--- a/README.md
+++ b/README.md
@@ -136,10 +136,10 @@ DREX also comes with a simple project drawer functionality
 
 ## Configuration
 
-There is no initial setup needed to use DREX
+There is no initial setup needed to use DREX 
 However you may configure certain settings to your liking
 
-Check out `:help drex-configuration` for more details about the individual options
+Check out `:help drex-configuration` for more details about the individual options 
 See also the wiki pages about [configuration](https://github.com/TheBlob42/drex.nvim/wiki/Configuration) and [custom actions](https://github.com/TheBlob42/drex.nvim/wiki/Custom-Actions) for more information about further customization
 
 <details>

--- a/README.md
+++ b/README.md
@@ -136,10 +136,10 @@ DREX also comes with a simple project drawer functionality
 
 ## Configuration
 
-There is no initial setup needed to use DREX 
+There is no initial setup needed to use DREX  
 However you may configure certain settings to your liking
 
-Check out `:help drex-configuration` for more details about the individual options 
+Check out `:help drex-configuration` for more details about the individual options  
 See also the wiki pages about [configuration](https://github.com/TheBlob42/drex.nvim/wiki/Configuration) and [custom actions](https://github.com/TheBlob42/drex.nvim/wiki/Custom-Actions) for more information about further customization
 
 <details>

--- a/doc/drex.txt
+++ b/doc/drex.txt
@@ -165,6 +165,7 @@ However you may configure certain settings to your liking.
 			return aname < bname
 		end,
 		drawer = {
+			side = 'left',
 			default_width = 30,
 			window_picker = {
 				enabled = true,
@@ -324,6 +325,7 @@ DRAWER                                             *drex-configuration-drawer*
 Options specific to the |drex-drawer| functionality:
 >
 	drawer = {
+		side = 'left',
 		default_width = 30,
 		window_picker = {
 			enabled = true,
@@ -331,6 +333,7 @@ Options specific to the |drex-drawer| functionality:
 		},
 	},
 <
+- `side` - the default side the drawer will open ('left' | 'right')
 - `default_width` - the default width of the drawer window (columns)
 
                                                           *drex-window-picker*

--- a/lua/drex/config/init.lua
+++ b/lua/drex/config/init.lua
@@ -2,12 +2,12 @@ local M = {}
 
 local defaults = {
     icons = {
-        file_default = "",
+        file_default = '',
         -- icons which are not used by nvim-web-devicons
-        dir_open = "",
-        dir_closed = "",
-        link = "",
-        others = "",
+        dir_open = '',
+        dir_closed = '',
+        link = '',
+        others = '',
     },
     colored_icons = true,
     hide_cursor = true,
@@ -26,6 +26,7 @@ local defaults = {
         return aname < bname
     end,
     drawer = {
+        side = 'left',
         default_width = 30,
         window_picker = {
             enabled = true,
@@ -38,60 +39,141 @@ local defaults = {
             -- always use visual mode linewise for better visibility
             ['v'] = 'V',
             -- open/close directories
-            ['l'] = { '<cmd>lua require("drex.elements").expand_element()<CR>', { desc = 'expand element' }},
-            ['h'] = { '<cmd>lua require("drex.elements").collapse_directory()<CR>', { desc = 'collapse directory' }},
-            ['<right>'] = { '<cmd>lua require("drex.elements").expand_element()<CR>', { desc = 'expand element' }},
-            ['<left>']  = { '<cmd>lua require("drex.elements").collapse_directory()<CR>', { desc = 'collapse directory'}},
-            ['<2-LeftMouse>'] = { '<LeftMouse><cmd>lua require("drex.elements").expand_element()<CR>', { desc = 'expand element' }},
-            ['<RightMouse>']  = { '<LeftMouse><cmd>lua require("drex.elements").collapse_directory()<CR>', { desc = 'collapse directory' }},
+            ['l'] = { '<cmd>lua require("drex.elements").expand_element()<CR>', { desc = 'expand element' } },
+            ['h'] = { '<cmd>lua require("drex.elements").collapse_directory()<CR>', { desc = 'collapse directory' } },
+            ['<right>'] = { '<cmd>lua require("drex.elements").expand_element()<CR>', { desc = 'expand element' } },
+            ['<left>'] = {
+                '<cmd>lua require("drex.elements").collapse_directory()<CR>',
+                { desc = 'collapse directory' },
+            },
+            ['<2-LeftMouse>'] = {
+                '<LeftMouse><cmd>lua require("drex.elements").expand_element()<CR>',
+                {
+                    desc = 'expand element',
+                },
+            },
+            ['<RightMouse>'] = {
+                '<LeftMouse><cmd>lua require("drex.elements").collapse_directory()<CR>',
+                {
+                    desc = 'collapse directory',
+                },
+            },
             -- open files in separate windows/tabs
-            ['<C-v>'] = { '<cmd>lua require("drex.elements").open_file("vs")<CR>', { desc = 'open file in vsplit' }},
-            ['<C-x>'] = { '<cmd>lua require("drex.elements").open_file("sp")<CR>', { desc = 'open file in split' }},
-            ['<C-t>'] = { '<cmd>lua require("drex.elements").open_file("tabnew", true)<CR>', { desc = 'open file in new tab' }},
+            ['<C-v>'] = { '<cmd>lua require("drex.elements").open_file("vs")<CR>', { desc = 'open file in vsplit' } },
+            ['<C-x>'] = { '<cmd>lua require("drex.elements").open_file("sp")<CR>', { desc = 'open file in split' } },
+            ['<C-t>'] = {
+                '<cmd>lua require("drex.elements").open_file("tabnew", true)<CR>',
+                {
+                    desc = 'open file in new tab',
+                },
+            },
             -- switch root directory
-            ['<C-l>'] = { '<cmd>lua require("drex.elements").open_directory()<CR>', { desc = 'open directory in new buffer' }},
-            ['<C-h>'] = { '<cmd>lua require("drex.elements").open_parent_directory()<CR>', { desc = 'open parent directory in new buffer' }},
+            ['<C-l>'] = {
+                '<cmd>lua require("drex.elements").open_directory()<CR>',
+                {
+                    desc = 'open directory in new buffer',
+                },
+            },
+            ['<C-h>'] = {
+                '<cmd>lua require("drex.elements").open_parent_directory()<CR>',
+                {
+                    desc = 'open parent directory in new buffer',
+                },
+            },
             -- manual reload
-            ['<F5>'] = { '<cmd>lua require("drex").reload_directory()<CR>', { desc = 'reload' }},
+            ['<F5>'] = { '<cmd>lua require("drex").reload_directory()<CR>', { desc = 'reload' } },
             -- jump around elements
-            ['gj'] = { '<cmd>lua require("drex.actions.jump").jump_to_next_sibling()<CR>', { desc = 'jump to next sibling' }},
-            ['gk'] = { '<cmd>lua require("drex.actions.jump").jump_to_prev_sibling()<CR>', { desc = 'jump to prev sibling' }},
-            ['gh'] = { '<cmd>lua require("drex.actions.jump").jump_to_parent()<CR>', { desc = 'jump to parent element' }},
+            ['gj'] = {
+                '<cmd>lua require("drex.actions.jump").jump_to_next_sibling()<CR>',
+                {
+                    desc = 'jump to next sibling',
+                },
+            },
+            ['gk'] = {
+                '<cmd>lua require("drex.actions.jump").jump_to_prev_sibling()<CR>',
+                {
+                    desc = 'jump to prev sibling',
+                },
+            },
+            ['gh'] = {
+                '<cmd>lua require("drex.actions.jump").jump_to_parent()<CR>',
+                {
+                    desc = 'jump to parent element',
+                },
+            },
             -- file actions
-            ['s'] = { '<cmd>lua require("drex.actions.stats").stats()<CR>', { desc = 'show element stats' }},
-            ['a'] = { '<cmd>lua require("drex.actions.files").create()<CR>', { desc = 'create element' }},
-            ['d'] = { '<cmd>lua require("drex.actions.files").delete("line")<CR>', { desc = 'delete element' }},
-            ['D'] = { '<cmd>lua require("drex.actions.files").delete("clipboard")<CR>', { desc = 'delete (clipboard)' }},
-            ['p'] = { '<cmd>lua require("drex.actions.files").copy_and_paste()<CR>', { desc = 'copy & paste (clipboard)' }},
-            ['P'] = { '<cmd>lua require("drex.actions.files").cut_and_move()<CR>', { desc = 'cut & move (clipboard)' }},
-            ['r'] = { '<cmd>lua require("drex.actions.files").rename()<CR>', { desc = 'rename element' }},
-            ['R'] = { '<cmd>lua require("drex.actions.files").multi_rename("clipboard")<CR>', { desc = 'rename (clipboard)' }},
+            ['s'] = { '<cmd>lua require("drex.actions.stats").stats()<CR>', { desc = 'show element stats' } },
+            ['a'] = { '<cmd>lua require("drex.actions.files").create()<CR>', { desc = 'create element' } },
+            ['d'] = { '<cmd>lua require("drex.actions.files").delete("line")<CR>', { desc = 'delete element' } },
+            ['D'] = {
+                '<cmd>lua require("drex.actions.files").delete("clipboard")<CR>',
+                {
+                    desc = 'delete (clipboard)',
+                },
+            },
+            ['p'] = {
+                '<cmd>lua require("drex.actions.files").copy_and_paste()<CR>',
+                {
+                    desc = 'copy & paste (clipboard)',
+                },
+            },
+            ['P'] = {
+                '<cmd>lua require("drex.actions.files").cut_and_move()<CR>',
+                {
+                    desc = 'cut & move (clipboard)',
+                },
+            },
+            ['r'] = { '<cmd>lua require("drex.actions.files").rename()<CR>', { desc = 'rename element' } },
+            ['R'] = {
+                '<cmd>lua require("drex.actions.files").multi_rename("clipboard")<CR>',
+                {
+                    desc = 'rename (clipboard)',
+                },
+            },
             -- search
-            ['/'] = { '<cmd>keepalt lua require("drex.actions.search").search()<CR>', { desc = 'search' }},
+            ['/'] = { '<cmd>keepalt lua require("drex.actions.search").search()<CR>', { desc = 'search' } },
             -- add/remove elements from clipboard
-            ['M'] = { '<cmd>DrexMark<CR>', { desc = 'mark element' }},
-            ['u'] = { '<cmd>DrexUnmark<CR>', { desc = 'unmark element' }},
-            ['m'] = { '<cmd>DrexToggle<CR>', { desc = 'toggle element' }},
-            ['cc'] = { '<cmd>lua require("drex.clipboard").clear_clipboard()<CR>', { desc = 'clear clipboard' }},
-            ['cs'] = { '<cmd>lua require("drex.clipboard").open_clipboard_window()<CR>', { desc = 'edit clipboard' }},
+            ['M'] = { '<cmd>DrexMark<CR>', { desc = 'mark element' } },
+            ['u'] = { '<cmd>DrexUnmark<CR>', { desc = 'unmark element' } },
+            ['m'] = { '<cmd>DrexToggle<CR>', { desc = 'toggle element' } },
+            ['cc'] = { '<cmd>lua require("drex.clipboard").clear_clipboard()<CR>', { desc = 'clear clipboard' } },
+            ['cs'] = { '<cmd>lua require("drex.clipboard").open_clipboard_window()<CR>', { desc = 'edit clipboard' } },
             -- string copy utilities
-            ['y'] = { '<cmd>lua require("drex.actions.text").copy_name()<CR>', { desc = 'copy element name' }},
-            ['Y'] = { '<cmd>lua require("drex.actions.text").copy_relative_path()<CR>', { desc = 'copy element relative path' }},
-            ['<C-y>'] = { '<cmd>lua require("drex.actions.text").copy_absolute_path()<CR>', { desc = 'copy element absolute path' }},
+            ['y'] = { '<cmd>lua require("drex.actions.text").copy_name()<CR>', { desc = 'copy element name' } },
+            ['Y'] = {
+                '<cmd>lua require("drex.actions.text").copy_relative_path()<CR>',
+                {
+                    desc = 'copy element relative path',
+                },
+            },
+            ['<C-y>'] = {
+                '<cmd>lua require("drex.actions.text").copy_absolute_path()<CR>',
+                {
+                    desc = 'copy element absolute path',
+                },
+            },
         },
         ['v'] = {
             -- file actions
-            ['d'] = { ':lua require("drex.actions.files").delete("visual")<CR>', { desc = 'delete elements' }},
-            ['r'] = { ':lua require("drex.actions.files").multi_rename("visual")<CR>', { desc = 'rename elements' }},
+            ['d'] = { ':lua require("drex.actions.files").delete("visual")<CR>', { desc = 'delete elements' } },
+            ['r'] = { ':lua require("drex.actions.files").multi_rename("visual")<CR>', { desc = 'rename elements' } },
             -- add/remove elements from clipboard
-            ['M'] = { ':DrexMark<CR>', { desc = 'mark elements' }},
-            ['u'] = { ':DrexUnmark<CR>', { desc = 'unmark elements' }},
-            ['m'] = { ':DrexToggle<CR>', { desc = 'toggle elements' }},
+            ['M'] = { ':DrexMark<CR>', { desc = 'mark elements' } },
+            ['u'] = { ':DrexUnmark<CR>', { desc = 'unmark elements' } },
+            ['m'] = { ':DrexToggle<CR>', { desc = 'toggle elements' } },
             -- string copy utilities
-            ['y'] = { ':lua require("drex.actions.text").copy_name(true)<CR>', { desc = 'copy element names' }},
-            ['Y'] = { ':lua require("drex.actions.text").copy_relative_path(true)<CR>', { desc = 'copy element relative paths' }},
-            ['<C-y>'] = { ':lua require("drex.actions.text").copy_absolute_path(true)<CR>', { desc = 'copy element absolute paths' }},
-        }
+            ['y'] = { ':lua require("drex.actions.text").copy_name(true)<CR>', { desc = 'copy element names' } },
+            ['Y'] = {
+                ':lua require("drex.actions.text").copy_relative_path(true)<CR>',
+                { desc = 'copy element relative paths' },
+            },
+            ['<C-y>'] = {
+                ':lua require("drex.actions.text").copy_absolute_path(true)<CR>',
+                {
+                    desc = 'copy element absolute paths',
+                },
+            },
+        },
     },
     on_enter = nil,
     on_leave = nil,
@@ -105,9 +187,14 @@ local defaults = {
 local function validate_icon(name, value)
     if not value or #value == 0 or value:find('[ /\\]') then
         vim.notify(
-            "Invalid icon value for '" .. name .. "': '" .. value .. "' icon has to be non-nil, can not be blank and must not contain ' ', '/' or '\\' characters!",
+            "Invalid icon value for '"
+                .. name
+                .. "': '"
+                .. value
+                .. "' icon has to be non-nil, can not be blank and must not contain ' ', '/' or '\\' characters!",
             vim.log.levels.ERROR,
-            { title = 'DREX' })
+            { title = 'DREX' }
+        )
         return false
     end
     return true
@@ -127,7 +214,9 @@ local function validate_window_picker_labels(labels)
 
     if #errors > 0 then
         vim.notify(
-            'Found invalid characters for `drawer.window_picker.labels`: "' .. table.concat(errors, '') .. '" fall back to default!',
+            'Found invalid characters for `drawer.window_picker.labels`: "'
+                .. table.concat(errors, '')
+                .. '" fall back to default!',
             vim.log.levels.ERROR,
             { title = 'DREX' }
         )
@@ -143,20 +232,22 @@ end
 local function validate_sorting(sorting)
     if sorting then
         if type(sorting) == 'function' then
-            local test_data = {{ 'x', 'file' }, { 'y', 'link' }, { 'z', 'directory' }}
+            local test_data = { { 'x', 'file' }, { 'y', 'link' }, { 'z', 'directory' } }
             local status_ok, error = pcall(table.sort, test_data, sorting)
             if not status_ok then
                 vim.notify(
                     'The provided sorting function throws an error: "' .. error .. '" fall back to default!',
                     vim.log.levels.ERROR,
-                    { title = 'DREX' })
+                    { title = 'DREX' }
+                )
                 return false
             end
         else
             vim.notify(
                 'The provided sorting is not a `function`, fall back to default!',
                 vim.log.levels.ERROR,
-                { title = 'DREX' })
+                { title = 'DREX' }
+            )
             return false
         end
     end
@@ -177,24 +268,34 @@ local function validate_keybindings(keybindings)
             if binding then
                 local t = type(binding)
                 if t == 'string' or t == 'function' then
-                    -- do nothing
+                -- do nothing
                 elseif t == 'table' then
                     if type(binding[1]) ~= 'string' and type(binding[1]) ~= 'function' then
-                        table.insert(errors, error_template:format(mode, key, 'first element has to be a function or string'))
+                        table.insert(
+                            errors,
+                            error_template:format(mode, key, 'first element has to be a function or string')
+                        )
                     end
 
                     if type(binding[2]) ~= 'table' then
                         table.insert(errors, error_template:format(mode, key, 'second element has to be a table'))
                     end
                 else
-                    table.insert(errors, error_template:format(mode, key, 'value has to be a string, a function or a list ('..t..')'))
+                    table.insert(
+                        errors,
+                        error_template:format(mode, key, 'value has to be a string, a function or a list (' .. t .. ')')
+                    )
                 end
             end
         end
     end
 
     if #errors > 0 then
-        vim.notify('There are problems with the keybindings, fall back to default!\n'..table.concat(errors, '\n'), vim.log.levels.WARN, { title = 'DREX' })
+        vim.notify(
+            'There are problems with the keybindings, fall back to default!\n' .. table.concat(errors, '\n'),
+            vim.log.levels.WARN,
+            { title = 'DREX' }
+        )
         return false
     end
 
@@ -262,7 +363,7 @@ function M.set_default_keybindings(buffer)
                 local opts = {
                     buffer = buffer,
                     silent = true,
-                    nowait = true
+                    nowait = true,
                 }
 
                 -- check for passed options table
@@ -275,7 +376,6 @@ function M.set_default_keybindings(buffer)
             end
         end
     end
-
 end
 
 return M

--- a/lua/drex/drawer.lua
+++ b/lua/drex/drawer.lua
@@ -59,7 +59,7 @@ end
 function M.open()
     local win = M.get_drawer_window()
     if not win then
-        local side = (config.options.drawer.side == 'left' and 'H' or 'L')
+        local side = (config.options.drawer.side == 'right' and 'L' or 'H')
         vim.cmd('vs')
         vim.cmd('wincmd ' .. side)
 

--- a/lua/drex/drawer.lua
+++ b/lua/drex/drawer.lua
@@ -5,21 +5,21 @@ local drex = require('drex')
 local utils = require('drex.utils')
 local config = require('drex.config')
 
-local drawer_widths = {}  -- save win width per tabpage
+local drawer_widths = {} -- save win width per tabpage
 local drawer_windows = {} -- save win id per tabpage
 
 -- during session load check for saved drawer configurations and restore them
 if vim.g.SessionLoad == 1 and vim.g.DrexDrawers then
     local saved = vim.tbl_map(tonumber, vim.split(vim.g.DrexDrawers, ':', {}))
-    for i=1,vim.tbl_count(saved),3 do
-        local tab   = saved[i] -- works because tabnr == tabid on session reload
-        local winnr = saved[i+1]
-        local width = saved[i+2]
+    for i = 1, vim.tbl_count(saved), 3 do
+        local tab = saved[i] -- works because tabnr == tabid on session reload
+        local winnr = saved[i + 1]
+        local width = saved[i + 2]
 
         for _, win in ipairs(api.nvim_tabpage_list_wins(tab)) do
             if winnr == api.nvim_win_get_number(win) then
                 drawer_windows[tab] = win
-                drawer_widths[tab]  = width
+                drawer_widths[tab] = width
                 api.nvim_win_set_width(win, width)
                 api.nvim_win_set_option(win, 'winfixwidth', true)
                 break
@@ -59,8 +59,9 @@ end
 function M.open()
     local win = M.get_drawer_window()
     if not win then
+        local side = (config.options.drawer.side == 'left' and 'H' or 'L')
         vim.cmd('vs')
-        vim.cmd('wincmd H')
+        vim.cmd('wincmd ' .. side)
 
         local tab = api.nvim_get_current_tabpage()
         win = api.nvim_get_current_win()
@@ -82,7 +83,11 @@ end
 function M.close()
     if M.get_drawer_window() then
         if vim.tbl_count(api.nvim_list_wins()) == 1 then
-            utils.echo("You can't close the DREX drawer if it is the last editor window (see ':h E444')", false, 'WarningMsg')
+            utils.echo(
+                "You can't close the DREX drawer if it is the last editor window (see ':h E444')",
+                false,
+                'WarningMsg'
+            )
             return
         end
 
@@ -132,7 +137,7 @@ function M.find_element(path, focus_drawer_window, resize_drawer_window)
     path = utils.expand_path(path)
 
     if not vim.loop.fs_lstat(path) then
-        vim.notify('The buffer path "'..path..'" does not point to an existing file!', vim.log.levels.ERROR, {})
+        vim.notify('The buffer path "' .. path .. '" does not point to an existing file!', vim.log.levels.ERROR, {})
         return
     end
 


### PR DESCRIPTION
Hi @TheBlob42, thank you so much for your awesome work on `drex.nvim`. Recently started using it and have been very happy switching over from `nvim-tree`!

One option I found I was missing dearly was the option to open the drawer on the right side. I've added an option to the drawer configuration which will allow a user to specify either `left` or `right` with a default of `left`. The documentation has been updated accordingly.

```lua
    drawer = {
        side = 'left', -- 'left' | 'right'
        default_width = 30,
        window_picker = {
            enabled = true,
            labels = 'abcdefghijklmnopqrstuvwxyz',
        },
    },
```

I had some trouble keeping the formatting uniform with you're own formatting, as there wasn't a `.stylua.toml` configuration in the repo. Hope that isn't too big of a problem. If it is, please let me know and I'll sort it out.

Thanks in advance!