### PR TITLE
chore: replace unmaintained actions-rs/* actions in CI workflow

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -14,15 +14,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Rust Setup
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
       # manual installation is needed because of an issue with goto statements otherwise
       # https://github.com/JohnnyMorganz/StyLua/issues/407
       - name: Cargo Install
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: stylua --features lua52
+        run: cargo install stylua --features lua52
       - name: Lua Format Check
         run: stylua --color always --check .


### PR DESCRIPTION
Basically all of the `actions-rs/*` actions are unmaintained. See <https://github.com/actions-rs/toolchain/issues/216> for more information. Due to their age they generate several warnings in CI runs, for example in https://github.com/TheBlob42/drex.nvim/actions/runs/4790293647:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions-rs/toolchain@v1, actions-rs/cargo@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

To get rid of those warnings the occurrences of `actions-rs/toolchain` are replaced by [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain), and the occurrences of `actions-rs/cargo` are replaced by direct invocations of `cargo`.