### PR TITLE
fix: calculate visible width using nvim_strwidth

### DIFF
--- a/lua/drex/drawer.lua
+++ b/lua/drex/drawer.lua
@@ -157,7 +157,7 @@ function M.find_element(path, focus_drawer_window, resize_drawer_window)
 
     if resize_drawer_window then
         api.nvim_win_call(drawer_window, function()
-            local element_width = utils.get_visible_width(api.nvim_get_current_line()) + 3 -- two for indentation and one as a small padding
+            local element_width = utils.get_visible_width(api.nvim_get_current_line()) + 1 -- one as a small padding
             local drawer_width = api.nvim_win_get_width(drawer_window)
             if element_width > drawer_width then
                 M.set_width(element_width, false, true)

--- a/lua/drex/utils.lua
+++ b/lua/drex/utils.lua
@@ -157,7 +157,7 @@ end
 ---@return number
 function M.get_visible_width(line)
     local indentation, icon, _, _, name = line:match(line_pattern)
-    return #indentation + #icon + 1 + #name -- one space between icon and element
+    return #indentation + api.nvim_strwidth(icon) + 1 + api.nvim_strwidth(name) -- one space between icon and element
 end
 
 -- ###############################################


### PR DESCRIPTION
Some multi-byte characters, specially icons, were causing the visible width to be reported incorrectly. As I understand it, `get_visible_width()` should return the number of visible cells occupied by the the line. This changes it to use `nvim_strwidth()` intead of directly relying on the byte length.

Also, when resizing the drawer, indentation was being counted twice. This is because `get_visible_width()` already considers the indentation size.

BTW, thanks for this great plugin!